### PR TITLE
Decoupled simulation loop from rendering loop

### DIFF
--- a/src/scene.ts
+++ b/src/scene.ts
@@ -10,6 +10,7 @@ export interface Viewport {
 
 export abstract class Scene {
   public readonly context: CanvasRenderingContext2D;
+  public simulationInterval: number = 10;
 
   protected shapes: Shape[] = [];
 
@@ -56,14 +57,30 @@ export abstract class Scene {
   }
 
   public start(): void {
+    this.startSimulation();
+    this.startRender();
+  }
+
+  private startSimulation(): void {
     const start = performance.now();
     let last = start;
 
-    const frame = (now: number) => {
+    const step = () => {
+      window.setTimeout(step, this.simulationInterval);
+
+      const now = performance.now();
       const time = now - start;
       const dt = now - last;
       last = now;
-      this.frame(time, dt);
+      this.update(time / 1000, dt / 1000);
+    };
+
+    window.setTimeout(step, this.simulationInterval);
+  }
+
+  private startRender(): void {
+    const frame = () => {
+      this.frame();
       window.requestAnimationFrame(frame);
     };
 
@@ -74,8 +91,7 @@ export abstract class Scene {
     this.context.clearRect(this.viewport.x, this.viewport.y, this.viewport.width, this.viewport.height);
   }
 
-  private frame(time: number, dt: number): void {
-    this.update(time / 1000, dt / 1000);
+  private frame(): void {
     this.render();
   }
 


### PR DESCRIPTION
This pull request makes the simulation update logic independent of the frame rate. It uses [`Window.setTimeout`](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setTimeout) to run `Scene.update`. One can change `Scene.simulationInterval` to change the simulation resolution. The default value is 10 milliseconds / 100 updates per second.

The reason I did not use [`Window.setInterval`](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/setInterval) is because it does not allow intervals shorter than 10ms.
> The time, in milliseconds (thousandths of a second), the timer should delay in between executions of the specified function or code. If this parameter is less than 10, a value of 10 is used.